### PR TITLE
Wrong assumption about default encoding for Java on Windows.

### DIFF
--- a/swc-example-serialization/src/main/java/org/example/Serializer.java
+++ b/swc-example-serialization/src/main/java/org/example/Serializer.java
@@ -450,7 +450,8 @@ public class Serializer
 			}
 			case XML:
 			{
-				getXmlSerializer().toXML(original, objBaos);
+				OutputStreamWriter osw = new OutputStreamWriter(objBaos, "UTF-8");
+				getXmlSerializer().toXML(original, osw);
 				objBaos.close();
 				break;
 			}


### PR DESCRIPTION
Please include this short fix. Else It wont maven build on windows because of failed tests.
