### PR TITLE
Experimental automatic language configuration generator

### DIFF
--- a/swc-engine/src/main/java/org/sweble/wikitext/engine/utils/LanguageConfigGenerator.java
+++ b/swc-engine/src/main/java/org/sweble/wikitext/engine/utils/LanguageConfigGenerator.java
@@ -1,7 +1,4 @@
 /**
- * Copyright 2011 The Open Source Research Group,
- *                University of Erlangen-Nürnberg
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
This class automatically generates a language specific wikiConfig via the wiki api sites. I think it would be a nice experimental feature for the sweble parser. It is just a first prototype and i only manually tested it a little bit with the german, english and french wikipedia.
