### PR TITLE
Current HEAD does not compile with 2.0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
       <dependency>
         <groupId>de.fau.cs.osr.utils</groupId>
         <artifactId>utils</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.0</version>
       </dependency>
 
       <!-- Parser Toolkit - Common -->


### PR DESCRIPTION
There's an incompatible change somewhere in the `de.fau.cs.osr.utils` project