### PR TITLE
Permit <pre> tag via template expansion, allow <b> and <i> along with `''` and `'''`

### DIFF
--- a/sweble-wikitext-components-parent/swc-parser-lazy/src/main/java/org/sweble/wikitext/parser/postprocessor/TreeBuilderInBody.java
+++ b/sweble-wikitext-components-parent/swc-parser-lazy/src/main/java/org/sweble/wikitext/parser/postprocessor/TreeBuilderInBody.java
@@ -274,7 +274,7 @@ public final class TreeBuilderInBody
 				startTagR34(n);
 				break;
 			case IMG:
-				throw new AssertionError("This must not happen!");
+				throw new UnsupportedOperationException("The HTML img tag is not permitted on MediaWiki.");
 				/*
 				case INPUT:
 				startTagR35(n);

--- a/sweble-wikitext-components-parent/swc-parser-lazy/src/main/java/org/sweble/wikitext/parser/postprocessor/TreeBuilderModeBase.java
+++ b/sweble-wikitext-components-parent/swc-parser-lazy/src/main/java/org/sweble/wikitext/parser/postprocessor/TreeBuilderModeBase.java
@@ -129,10 +129,10 @@ public class TreeBuilderModeBase
 
 	protected static void addRtDataOfImEndTag(WtNode finish, WtRtData etRtd)
 	{
-		switch (finish.getNodeType())
+		switch (getNodeType(finish))
 		{
-			case WtNode.NT_BOLD:
-			case WtNode.NT_ITALICS:
+			case B:
+			case I:
 			{
 				RtData feRtd = finish.getRtd();
 				if (feRtd == null)
@@ -162,7 +162,7 @@ public class TreeBuilderModeBase
 			
 			default:
 				// Finish is assumed to be WtBold, WtItalics or an WtXmlElement node
-				throw new AssertionError();
+				throw new IllegalArgumentException("Node was assumed to be bold or italics, but was type "+getNodeType(finish));
 		}
 	}
 }


### PR DESCRIPTION
Resolves #43, and also replaces associated Internal Error messages with more helpful error messages #35 (but not all of them)
