### PR TITLE
Don't throw exepction when an alias is registered

### DIFF
--- a/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/config/WikiConfigImpl.java
+++ b/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/config/WikiConfigImpl.java
@@ -48,6 +48,8 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.util.JAXBSource;
 import javax.xml.transform.Source;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sweble.wikitext.engine.ParserFunctionBase;
 import org.sweble.wikitext.engine.TagExtensionBase;
 import org.sweble.wikitext.engine.nodes.EngineNodeFactoryImpl;
@@ -76,6 +78,7 @@ public class WikiConfigImpl
 		implements
 			WikiConfig
 {
+	private static final Logger logger = LoggerFactory.getLogger(WikiConfigImpl.class);
 
 	@XmlElement()
 	private final ParserConfigImpl parserConfig;
@@ -367,7 +370,6 @@ public class WikiConfigImpl
 	public void addI18nAlias(I18nAliasImpl alias)
 	{
 		I18nAliasImpl old = aliasesById.get(alias.getId());
-
 		if (old == alias || (old != null && old.equals(alias)))
 			throw new IllegalArgumentException("This alias is already registered: " + alias.getId());
 
@@ -379,15 +381,15 @@ public class WikiConfigImpl
 			String lcAlias = a.toLowerCase();
 			I18nAliasImpl old2 = nameToAliasMap.get(lcAlias);
 
-			if (old2 == alias)
-				throw new IllegalArgumentException("This alias (`" + alias.getId() + "') registeres the name `" + a + "' twice.");
-
-			if (old2 != null)
-				System.out.println("The name `" + a + "' was already registered by the alias `" + old2.getId() + "' but we are also registering it for `" + alias.getId() + "'.");
-
-			nameToAliasMap.put(lcAlias, alias);
+			if (old2 == alias) {
+				throw new IllegalArgumentException("This alias (`" + alias.getId() + "') registers the name `" + a + "' twice.");
+			} else if (old2 != null) {
+				logger.warn("The name {} has been already registered to an id, so it cannot be registered to {}", lcAlias, alias.getId());
+				continue;
+			} else {
+				nameToAliasMap.put(lcAlias, alias);
+			}
 		}
-
 		aliasesById.put(alias.getId(), alias);
 	}
 

--- a/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/config/WikiConfigImpl.java
+++ b/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/config/WikiConfigImpl.java
@@ -383,7 +383,7 @@ public class WikiConfigImpl
 				throw new IllegalArgumentException("This alias (`" + alias.getId() + "') registeres the name `" + a + "' twice.");
 
 			if (old2 != null)
-				throw new IllegalArgumentException("The name `" + a + "' was already registered by the alias `" + old2.getId() + "' when trying to register it for alias `" + alias.getId() + "'.");
+				System.out.println("The name `" + a + "' was already registered by the alias `" + old2.getId() + "' but we are also registering it for `" + alias.getId() + "'.");
 
 			nameToAliasMap.put(lcAlias, alias);
 		}

--- a/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/utils/LanguageConfigGenerator.java
+++ b/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/utils/LanguageConfigGenerator.java
@@ -137,12 +137,8 @@ public class LanguageConfigGenerator
 			NamedNodeMap attributes = apiI18nAlias.getAttributes();
 
 			String name = attributes.getNamedItem("name").getNodeValue();
-			boolean isCaseSensitive = false;
-			Node caseSensitive = attributes.getNamedItem("case-sensitive");
-			if (caseSensitive != null)
-			{
-				isCaseSensitive = true;
-			}
+
+			boolean isCaseSensitive = attributes.getNamedItem("case-sensitive") != null;
 
 			I18nAliasImpl defaultAlias = template.getI18nAliasById(name);
 			String prefix = "";
@@ -203,10 +199,10 @@ public class LanguageConfigGenerator
 			{
 				wikiConfig.addI18nAlias(i18nAlias);
 			}
-			catch (Exception e)
+			catch (IllegalArgumentException e)
 			{
 				// TODO resolve conflicts problem
-				e.printStackTrace();
+				System.out.println(e.getMessage());
 			}
 		}
 	}

--- a/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/utils/LanguageConfigGenerator.java
+++ b/sweble-wikitext-components-parent/swc-engine/src/main/java/org/sweble/wikitext/engine/utils/LanguageConfigGenerator.java
@@ -25,6 +25,8 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.collections.map.MultiValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sweble.wikitext.engine.config.I18nAliasImpl;
 import org.sweble.wikitext.engine.config.InterwikiImpl;
 import org.sweble.wikitext.engine.config.NamespaceImpl;
@@ -41,6 +43,9 @@ import org.xml.sax.SAXException;
  */
 public class LanguageConfigGenerator
 {
+
+	private static final Logger logger = LoggerFactory.getLogger(LanguageConfigGenerator.class);
+
 	public static final String API_ENDPOINT_MAGICWORDS =
 			".wikipedia.org/w/api.php?action=query&meta=siteinfo&siprop=magicwords&format=xml";
 
@@ -202,7 +207,7 @@ public class LanguageConfigGenerator
 			catch (IllegalArgumentException e)
 			{
 				// TODO resolve conflicts problem
-				System.out.println(e.getMessage());
+				logger.warn(e.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
Connects to #72 , the main problem is that some parsing functions expect specific aliases to be registered within the wikiconfig, e.g. the name space parsing function expects `ns`. Now, in some cases these aliases are not registered because a different alias was registered to the same name. 
This PR allows for multiple alias registration, which in turn allows for the parsing functions to be configured properly. From the interpreter (previously broken)

```
scala> import org.sweble.wikitext.engine.utils.LanguageConfigGenerator
import org.sweble.wikitext.engine.utils.LanguageConfigGenerator

scala> val config = LanguageConfigGenerator.generateWikiConfig("ja")
The name `sub' was already registered by the alias `sub' but we are also registering it for  `img_sub'.
The name `名前空間:' was already registered by the alias `namespace' but we are also registering it for  `ns'.
The name `noreplace' was already registered by the alias `shortdesc_noreplace' but we are also registering it for  `defaultsort_noreplace'.
The name `noerror' was already registered by the alias `defaultsort_noerror' but we are also registering it for  `displaytitle_noerror'.
The name `noreplace' was already registered by the alias `defaultsort_noreplace' but we are also registering it for  `displaytitle_noreplace'.
config: org.sweble.wikitext.engine.config.WikiConfig = org.sweble.wikitext.engine.config.WikiConfigImpl@523072fe
```